### PR TITLE
bitmex crashes in parse_transaction_status

### DIFF
--- a/python/ccxt/async_support/bitmex.py
+++ b/python/ccxt/async_support/bitmex.py
@@ -478,7 +478,8 @@ class bitmex (Exchange):
             amount = abs(amount)
         else:
             direction = 'in'
-        status = self.parse_transaction_status(item, 'transactStatus')
+
+        status = self.parse_transaction_status(self.safe_string(item, 'transactStatus'))
         return {
             'info': item,
             'id': id,


### PR DESCRIPTION
  File "../ccxt/bitmex.py", line 481, in parse_ledger_entry
    status = self.parse_transaction_status(item, 'transactStatus')
TypeError:
parse_transaction_status() takes 2 positional arguments but 3 were given